### PR TITLE
update installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,11 @@ Cyclone is a script for generating and executing filament winding toolpaths. It 
 
 Download and Setup
 -------
-Cyclone is currently provided ony as the source code, which can be cloned or downloaded from this repository. The script requires [node.js](https://nodejs.org/)) to run. Once node.js is installed and Cyclone is downloaded, navigate to the Cyclone directory in a terminal and install its dependencies with `npm i`.
+Cyclone is currently provided ony as the source code, which can be cloned or downloaded from this repository. The script requires [node.js](https://nodejs.org/)) to run. Once node.js is installed and Cyclone is downloaded, navigate to the Cyclone directory in a terminal and install its dependencies with: 
+```
+npm install canvas
+npm i
+```
 
 Machine Configuration
 -------


### PR DESCRIPTION
This PR implements the solution in Issue #1 posted by [@JamezN42](https://github.com/reilleya/cyclone/issues/1#issuecomment-1905241093).

Running `npm install canvas` is a necessary step before running `npm i` to install cyclone's dependencies. Removing the `node_modules` directory beforehand if it exists is advised.


Tested on MacOS 14 Sonoma.